### PR TITLE
fix(tester): use `vm` instead of `vm2`

### DIFF
--- a/packages/@power-doctest/tester/package.json
+++ b/packages/@power-doctest/tester/package.json
@@ -40,13 +40,12 @@
   "dependencies": {
     "@power-doctest/core": "^5.3.2",
     "@power-doctest/types": "^5.3.1",
-    "power-assert": "^1.6.1",
-    "vm2": "^3.9.3"
+    "power-assert": "^1.6.1"
   },
   "devDependencies": {
     "@power-doctest/javascript": "^5.3.1",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^15.0.2",
+    "@types/node": "^18.16.19",
     "cross-env": "^7.0.3",
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",

--- a/packages/@power-doctest/tester/src/index.ts
+++ b/packages/@power-doctest/tester/src/index.ts
@@ -200,9 +200,7 @@ Also, you should consider to use { "runMode": "any" }`
                         ...context,
                         ...options.requireMock,
                     },
-                    {
-                        microtaskMode: "afterEvaluate",
-                    }
+                    {}
                 ),
                 {
                     timeout,

--- a/packages/@power-doctest/tester/src/index.ts
+++ b/packages/@power-doctest/tester/src/index.ts
@@ -181,6 +181,10 @@ Also, you should consider to use { "runMode": "any" }`
                         if (moduleName === "power-assert") {
                             return assert;
                         }
+                        // options.requireMock
+                        if (options.requireMock && Object.hasOwnProperty.call(options.requireMock, moduleName)) {
+                            return options.requireMock[moduleName];
+                        }
                         return require(moduleName);
                     },
                     [postCallbackName]: (_id: string) => {
@@ -197,7 +201,6 @@ Also, you should consider to use { "runMode": "any" }`
                     },
                     ...HostBuildIns,
                     ...context,
-                    ...options.requireMock,
                 }),
                 {
                     timeout,

--- a/packages/@power-doctest/tester/src/index.ts
+++ b/packages/@power-doctest/tester/src/index.ts
@@ -176,32 +176,29 @@ Also, you should consider to use { "runMode": "any" }`
                 filename: options.filePath,
             });
             script.runInNewContext(
-                vm.createContext(
-                    {
-                        require: (moduleName: string) => {
-                            if (moduleName === "power-assert") {
-                                return assert;
-                            }
-                            return require(moduleName);
-                        },
-                        [postCallbackName]: (_id: string) => {
-                            countOfExecutedAssertion++;
-                            if (runMode === "all" && countOfExecutedAssertion === totalAssertionCount) {
-                                // when all finish
-                                restoreListener();
-                                resolve();
-                            } else if (runMode === "any") {
-                                // when anyone finish
-                                restoreListener();
-                                resolve();
-                            }
-                        },
-                        ...HostBuildIns,
-                        ...context,
-                        ...options.requireMock,
+                vm.createContext({
+                    require: (moduleName: string) => {
+                        if (moduleName === "power-assert") {
+                            return assert;
+                        }
+                        return require(moduleName);
                     },
-                    {}
-                ),
+                    [postCallbackName]: (_id: string) => {
+                        countOfExecutedAssertion++;
+                        if (runMode === "all" && countOfExecutedAssertion === totalAssertionCount) {
+                            // when all finish
+                            restoreListener();
+                            resolve();
+                        } else if (runMode === "any") {
+                            // when anyone finish
+                            restoreListener();
+                            resolve();
+                        }
+                    },
+                    ...HostBuildIns,
+                    ...context,
+                    ...options.requireMock,
+                }),
                 {
                     timeout,
                 }

--- a/packages/@power-doctest/tester/src/index.ts
+++ b/packages/@power-doctest/tester/src/index.ts
@@ -175,37 +175,35 @@ Also, you should consider to use { "runMode": "any" }`
             const script = new vm.Script(poweredCode, {
                 filename: options.filePath,
             });
-            script.runInNewContext(
-                vm.createContext({
-                    require: (moduleName: string) => {
-                        if (moduleName === "power-assert") {
-                            return assert;
-                        }
-                        // options.requireMock
-                        if (options.requireMock && Object.hasOwnProperty.call(options.requireMock, moduleName)) {
-                            return options.requireMock[moduleName];
-                        }
-                        return require(moduleName);
-                    },
-                    [postCallbackName]: (_id: string) => {
-                        countOfExecutedAssertion++;
-                        if (runMode === "all" && countOfExecutedAssertion === totalAssertionCount) {
-                            // when all finish
-                            restoreListener();
-                            resolve();
-                        } else if (runMode === "any") {
-                            // when anyone finish
-                            restoreListener();
-                            resolve();
-                        }
-                    },
-                    ...HostBuildIns,
-                    ...context,
-                }),
-                {
-                    timeout,
-                }
-            );
+            const vmContext = vm.createContext({
+                require: (moduleName: string) => {
+                    if (moduleName === "power-assert") {
+                        return assert;
+                    }
+                    // options.requireMock
+                    if (options.requireMock && Object.hasOwnProperty.call(options.requireMock, moduleName)) {
+                        return options.requireMock[moduleName];
+                    }
+                    return require(moduleName);
+                },
+                [postCallbackName]: (_id: string) => {
+                    countOfExecutedAssertion++;
+                    if (runMode === "all" && countOfExecutedAssertion === totalAssertionCount) {
+                        // when all finish
+                        restoreListener();
+                        resolve();
+                    } else if (runMode === "any") {
+                        // when anyone finish
+                        restoreListener();
+                        resolve();
+                    }
+                },
+                ...HostBuildIns,
+                ...context,
+            });
+            script.runInNewContext(vmContext, {
+                timeout,
+            });
         } catch (error) {
             restoreListener();
             reject(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
+"@types/node@^18.16.19":
+  version "18.16.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
+  integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -744,7 +749,7 @@ acorn-es7-plugin@^1.0.12:
   resolved "https://registry.yarnpkg.com/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz#f2ee1f3228a90eead1245f9ab1922eb2e71d336b"
   integrity sha1-8u4fMiipDurRJF+asZIusucdM2s=
 
-acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -759,7 +764,7 @@ acorn@^5.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^8.4.1, acorn@^8.7.0:
+acorn@^8.4.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -5974,14 +5979,6 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vm2@^3.9.3:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.9.tgz#c0507bc5fbb99388fad837d228badaaeb499ddc5"
-  integrity sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==
-  dependencies:
-    acorn "^8.7.0"
-    acorn-walk "^8.2.0"
 
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- fix #32 

Use `vm` module directly.

## Note

- I do not understand that `HostBuildIns` cover all global objects?