### PR TITLE
feat: improve error messages for comment assertion parsing

### DIFF
--- a/packages/comment-to-assert/test/comment-to-assert-test.ts
+++ b/packages/comment-to-assert/test/comment-to-assert-test.ts
@@ -10,4 +10,28 @@ describe("comment-to-assert", function () {
             });
         });
     });
+
+    describe("error messages for comment parsing", function () {
+        it("should throw error with line number information for standalone comment", function () {
+            assert.throws(
+                () => {
+                    const code = `
+                    const a = 1;
+                    const b = 2;
+                    const c = 3;
+                    // => "missing expression"
+                `;
+                    toAssertFromSource(code);
+                },
+                (error: Error) => {
+                    console.log("Improved error message:", error.message);
+                    assert.match(error.message, /Cannot add assertion to VariableDeclaration/);
+                    assert.match(error.message, /at line 4/);
+                    assert.match(error.message, /Comment assertions/);
+                    assert.match(error.message, /can only be added to expressions, not declarations/);
+                    return true;
+                },
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Summary

This PR improves error messages for comment assertion parsing to address issue #45.

### Changes Made

- **Enhanced error handling**: Added try-catch blocks with line number information for better error reporting
- **Declaration validation**: Added validation to prevent assertions on declarations (VariableDeclaration, FunctionDeclaration, etc.)
- **Line number information**: All errors now include line numbers when available
- **Contextual error messages**: Errors include the actual comment content and helpful suggestions

### Before
```
@babel/template placeholder "ACTUAL_NODE": Property arguments[0] of CallExpression expected node to be of a type ["Expression","SpreadElement","ArgumentPlaceholder"] but instead got "VariableDeclaration"
```

### After
```
Cannot add assertion to VariableDeclaration at line 4. Comment assertions (// => "missing expression") can only be added to expressions, not declarations. Try adding the assertion after an expression statement instead.
```

### Additional Improvements

- Parse errors now include line numbers: `Error at line 3: Unexpected token, expected "," (1:9)`
- Clear guidance on how to fix common mistakes
- Better developer experience with actionable error messages

### Test Coverage

Added comprehensive test case to verify the improved error message format includes:
- Line number information
- Clear problem description  
- Helpful suggestions for resolution

### Breaking Changes

None - this only improves error messages without changing functionality.

### Related Issues

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)